### PR TITLE
Fallback to hard-coded libstrace dependencies on pkg-config failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -471,10 +471,11 @@ if(strip)
   set_target_properties(rr PROPERTIES LINK_FLAGS "-s")
 endif()
 
-# libdw is needed by libstrace
-exec_program(pkg-config
-             ARGS libdw --cflags --libs --static
-             OUTPUT_VARIABLE CMAKE_DW_LIBS)
+# libdw dependencies for libstrace
+execute_process(COMMAND bash
+                "-c"
+                "pkg-config libdw --cflags --libs --static 2>/dev/null || printf %s -ldwarf"
+                OUTPUT_VARIABLE CMAKE_DW_LIBS)
 
 target_link_libraries(rr
   ${CMAKE_DL_LIBS}


### PR DESCRIPTION
The pkg-config spec for `libdw` isn't always provided, so
hard-code the relevant libraries if pkg-config fails. For
example, Fedora changed the library name from `-ldw` to
`-ldwarf` and doesn't even provide a `pkg-config` spec
at all...

Signed-off-by: Joey Pabalinas <joeypabalinas@gmail.com>