### PR TITLE
Fix build failures on x86-64 caused by new glibc and capnproto versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -463,6 +463,7 @@ endif()
 add_custom_target(libstrace
                   ALL
                   WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/third-party/strace"
+                  COMMAND ./bootstrap
                   COMMAND ./build_libstrace.sh
                   COMMAND cp libstrace.a libstrace.so "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}"
                   VERBATIM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set(FLAGS_COMMON "-msse2 -D__MMX__ -D__SSE__ -D__SSE2__ -D__USE_LARGEFILE64 -pth
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${FLAGS_COMMON} -Wstrict-prototypes -std=gnu11")
 # Define __STDC_LIMIT_MACROS so |#include <stdint.h>| works as expected.
 # Define __STDC_FORMAT_MACROS so |#include <inttypes.h>| works as expected.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++11")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${FLAGS_COMMON} -D__STDC_LIMIT_MACROS -D__STDC_FORMAT_MACROS -std=c++14")
 set(CMAKE_ASM_FLAGS "${CMAKE_ASM_FLAGS} -g3")
 
 set(RR_FLAGS_DEBUG "-Wall -Wextra -Wno-error -O0 -DDEBUG -UNDEBUG")

--- a/third-party/strace/bootstrap
+++ b/third-party/strace/bootstrap
@@ -27,4 +27,4 @@ done
 
 autoreconf -f -i .
 ./configure --enable-stacktrace=no --without-libunwind --with-libdw
-echo > bootstrap.d
+:> bootstrap.d


### PR DESCRIPTION
Adds the shadow stack pointer member of ucontext_t needed by newer glibc versions and change g++'s standard revision to C++14 using  `-std=c++14` which is needed by capnproto versions after 0.7.0.