### PR TITLE
Unconditionally clean libstrace.so and libstrace.a before builds

### DIFF
--- a/third-party/strace/Makefile.libstrace
+++ b/third-party/strace/Makefile.libstrace
@@ -36,11 +36,14 @@ all:
 bootstrap.d:
 	@./bootstrap
 
-shared:
+shared: cleanlibs
 	@$(MAKE) -f $(THIS_MAKEFILE) libstrace.so
 
-static:
+static: cleanlibs
 	@$(MAKE) -f $(THIS_MAKEFILE) libstrace.a
+
+cleanlibs:
+	@$(RM) -fv -- libstrace.so libstrace.a
 
 libstrace.so: libstrace.a
 	$(LD) -shared $< $(LDFLAGS) $(LDLIBS) -Wl,-soname,$@.$(MAJOR) -o $@.$(MAJOR).$(MINOR).$(PATCH)


### PR DESCRIPTION
Avoid stale shared and static libraries from older compilations; unlike the other object files in this repository, these might have versioning dependencies and thus requiring a rebuild which `make` is unaware of.

Signed-off-by: Joey Pabalinas <joeypabalinas@gmail.com>