### PR TITLE
Output event number for syscall

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -1106,6 +1106,10 @@ void RecordSession::syscall_state_changed(RecordTask* t,
         syscall_exiting_trace(&tcp, NULL, res);
         // And pass it in here
         syscall_exiting_finish(&tcp);
+        //Output event number
+        std::stringstream eventstring;
+        eventstring << t->rec_tid << "  +++ " << t->trace_time() << " +++\n";
+        fwrite(eventstring.str().c_str(), 1, eventstring.str().length(), strace_outfile);
       }
 
       return;


### PR DESCRIPTION
NOTE:  I had a change of heart and reverted this change.  I didn't want people accidentally getting this version of rr along with an incompatible version of rrapper.  I'll merge this capability into both repos once its been well tested

Output the event number of a given syscall on the following line in the
strace recording.  Use the +++ format so posix-omni-parser doesn't blow
up.

