### PR TITLE
Check the return code of fopening strace_outfile

### DIFF
--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -924,7 +924,9 @@ void RecordSession::syscall_state_changed(RecordTask* t,
 
       if(this->strace_output) {
         if (strace_outfile == NULL) {
-          strace_outfile = fopen("strace_out.strace", "w");
+          if ((strace_outfile = fopen("strace_out.strace", "w")) == NULL) {
+            FATAL() << "Unable to open strace log file for writing";
+          }
         }
         // Set up global reference to the current task to call from our
         // overridden copies of umoven and umovestr

--- a/src/RecordSession.cc
+++ b/src/RecordSession.cc
@@ -925,7 +925,7 @@ void RecordSession::syscall_state_changed(RecordTask* t,
       if(this->strace_output) {
         if (strace_outfile == NULL) {
           if ((strace_outfile = fopen("strace_out.strace", "w")) == NULL) {
-            FATAL() << "Unable to open strace log file for writing";
+            FATAL() << "Unable to open strace log file for writing: " << strerror(errno);
           }
         }
         // Set up global reference to the current task to call from our


### PR DESCRIPTION
In the case we can't open `strace_outfile` for writing (e.g. the cwd is not writable by the current user), gracefully exit with a message instead of segfaulting later on.